### PR TITLE
Minimum fix for MacOS, possibly

### DIFF
--- a/madcad/rendering.py
+++ b/madcad/rendering.py
@@ -42,31 +42,34 @@
 				QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 '''
 
+import traceback
 from copy import copy, deepcopy
 from operator import itemgetter
-import traceback
 
 import moderngl as mgl
 import numpy.core as np
-
-from PyQt5.QtCore import Qt, QPoint, QEvent
-from PyQt5.QtWidgets import QApplication, QWidget, QOpenGLWidget
-from PyQt5.QtGui import QSurfaceFormat, QMouseEvent, QInputEvent, QKeyEvent, QTouchEvent, QFocusEvent
-
 from PIL import Image
+from PyQt5.QtCore import QEvent, QPoint, Qt
+from PyQt5.QtGui import (QFocusEvent, QInputEvent, QKeyEvent, QMouseEvent,
+                         QSurfaceFormat, QTouchEvent)
+from PyQt5.QtWidgets import QApplication, QOpenGLWidget, QWidget
 
-from .mathutils import *
-from .common import resourcedir
 from . import settings
-
+from .common import resourcedir
+from .mathutils import *
 from .nprint import nprint
-
 
 # minimum opengl version required by the rendering pipeline
 opengl_version = (3,3)
 # shared open gl context, None if not yet initialized
 global_context = None
 
+def qt_surface_format():
+    fmt = QSurfaceFormat()
+    fmt.setVersion(*opengl_version)
+    fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+    fmt.setSamples(4)
+    return fmt
 
 def show(scene:dict, interest:Box=None, size=uvec2(400,400), projection=None, navigation=None, **options):
 	''' 
@@ -89,12 +92,8 @@ def show(scene:dict, interest:Box=None, size=uvec2(400,400), projection=None, na
 	# retro-compatibility fix, shall be removed in future versions
 	if 'options' in options:	options.update(options['options'])
 	if not isinstance(scene, Scene):	scene = Scene(scene, options)
-
-	fmt = QSurfaceFormat()
-	fmt.setVersion(*opengl_version)
-	fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
-	fmt.setSamples(4)
-	QSurfaceFormat.setDefaultFormat(fmt)
+	
+	QSurfaceFormat.setDefaultFormat(qt_surface_format())
 
 	app = QApplication.instance()
 	created = False
@@ -1026,11 +1025,7 @@ class View(ViewCommon, QOpenGLWidget):
 	def __init__(self, scene, projection=None, navigation=None, parent=None):
 		# super init
 		QOpenGLWidget.__init__(self, parent)
-		# fmt = QSurfaceFormat()
-		# fmt.setVersion(*opengl_version)
-		# fmt.setProfile(QSurfaceFormat.CoreProfile)
-		# fmt.setSamples(4)
-		# self.setFormat(fmt)
+		self.setFormat(qt_surface_format())
 		
 		# ugly trick to receive interaction events in a different function than QOpenGLWidget.event (that one is locking the GIL during the whole rendering, killing any possibility of having a computing thread aside)
 		# that event reception should be in the current widget ...

--- a/madcad/rendering.py
+++ b/madcad/rendering.py
@@ -90,6 +90,12 @@ def show(scene:dict, interest:Box=None, size=uvec2(400,400), projection=None, na
 	if 'options' in options:	options.update(options['options'])
 	if not isinstance(scene, Scene):	scene = Scene(scene, options)
 
+	fmt = QSurfaceFormat()
+	fmt.setVersion(*opengl_version)
+	fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+	fmt.setSamples(4)
+	QSurfaceFormat.setDefaultFormat(fmt)
+
 	app = QApplication.instance()
 	created = False
 	if not app:
@@ -764,7 +770,7 @@ class ViewCommon:
 		# prepare the view uniforms
 		w, h = self.fb_screen.size
 		self.uniforms['view'] = view = self.navigation.matrix()
-		self.uniforms['proj'] = proj = self.projection.matrix(w/h, self.navigation.distance)
+		self.uniforms['proj'] = proj = self.projection.matrix(w/h if h > 0 else 0, self.navigation.distance)
 		self.uniforms['projview'] = proj * view
 		self.fresh.clear()
 
@@ -1020,11 +1026,11 @@ class View(ViewCommon, QOpenGLWidget):
 	def __init__(self, scene, projection=None, navigation=None, parent=None):
 		# super init
 		QOpenGLWidget.__init__(self, parent)
-		fmt = QSurfaceFormat()
-		fmt.setVersion(*opengl_version)
-		fmt.setProfile(QSurfaceFormat.CoreProfile)
-		fmt.setSamples(4)
-		self.setFormat(fmt)
+		# fmt = QSurfaceFormat()
+		# fmt.setVersion(*opengl_version)
+		# fmt.setProfile(QSurfaceFormat.CoreProfile)
+		# fmt.setSamples(4)
+		# self.setFormat(fmt)
 		
 		# ugly trick to receive interaction events in a different function than QOpenGLWidget.event (that one is locking the GIL during the whole rendering, killing any possibility of having a computing thread aside)
 		# that event reception should be in the current widget ...


### PR DESCRIPTION
This is the reduced fix for MacOS, this time without also upgrading PyQt to 6.

This is what's required on my device. Without it, I still get the division by zero error.
The change on line 767 is not strictly necessary.

It's possible that there are other ways to achieve what I do here, I am not particularly familiar with OpenGL or PyQt, just got to this answer thanks to this forum post: https://forum.qt.io/topic/75759/qopengl-on-mac-qcocoaglcontext-falling-back-to-unshared-context/3 