### PR TITLE
Allow to pass more options for meshes

### DIFF
--- a/madcad/displays.py
+++ b/madcad/displays.py
@@ -247,7 +247,7 @@ class SolidDisplay(Display):
 	def __init__(self, scene, positions, normals, faces, lines, idents, color=None, options:dict = None):
 		self.box = npboundingbox(positions)
 		
-		self.options = scene.options
+		self.options = scene.options.copy()
 		self.options.update(options)
 		# if we can make backward-breaking changes, remove color as parameter, use instead:
 		# color = options["color"] if options is not None and "color" in options else None

--- a/madcad/displays.py
+++ b/madcad/displays.py
@@ -244,9 +244,13 @@ from .mathutils import norminf, length2
 
 class SolidDisplay(Display):
 	''' Display render Meshes '''
-	def __init__(self, scene, positions, normals, faces, lines, idents, color=None):
+	def __init__(self, scene, positions, normals, faces, lines, idents, color=None, options:dict = None):
 		self.box = npboundingbox(positions)
+		
 		self.options = scene.options
+		self.options.update(options)
+		# if we can make backward-breaking changes, remove color as parameter, use instead:
+		# color = options["color"] if options is not None and "color" in options else None
 		
 		s = settings.display
 		color = fvec3(color or s['solid_color'])

--- a/madcad/mesh/mesh.py
+++ b/madcad/mesh/mesh.py
@@ -670,7 +670,8 @@ class Mesh(NMesh):
 				typedlist_to_numpy(m.faces, 'u4'),
 				typedlist_to_numpy(edges, 'u4'),
 				typedlist_to_numpy(idents, 'u4'),
-				color = self.options.get('color'),
+				self.options.get('color'),
+				self.options,
 				)
 	
 	def __repr__(self):

--- a/madcad/rendering.py
+++ b/madcad/rendering.py
@@ -90,6 +90,12 @@ def show(scene:dict, interest:Box=None, size=uvec2(400,400), projection=None, na
 	if 'options' in options:	options.update(options['options'])
 	if not isinstance(scene, Scene):	scene = Scene(scene, options)
 
+	fmt = QSurfaceFormat()
+	fmt.setVersion(*opengl_version)
+	fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+	fmt.setSamples(4)
+	QSurfaceFormat.setDefaultFormat(fmt)
+
 	app = QApplication.instance()
 	created = False
 	if not app:
@@ -764,7 +770,7 @@ class ViewCommon:
 		# prepare the view uniforms
 		w, h = self.fb_screen.size
 		self.uniforms['view'] = view = self.navigation.matrix()
-		self.uniforms['proj'] = proj = self.projection.matrix(w/h, self.navigation.distance)
+		self.uniforms['proj'] = proj = self.projection.matrix(w/h if h > 0 else 0, self.navigation.distance)
 		self.uniforms['projview'] = proj * view
 		self.fresh.clear()
 
@@ -1020,11 +1026,11 @@ class View(ViewCommon, QOpenGLWidget):
 	def __init__(self, scene, projection=None, navigation=None, parent=None):
 		# super init
 		QOpenGLWidget.__init__(self, parent)
-		fmt = QSurfaceFormat()
-		fmt.setVersion(*opengl_version)
-		fmt.setProfile(QSurfaceFormat.CoreProfile)
-		fmt.setSamples(4)
-		self.setFormat(fmt)
+		# fmt = QSurfaceFormat()
+		# fmt.setVersion(*opengl_version)
+		# fmt.setProfile(QSurfaceFormat.CoreProfile)
+		# fmt.setSamples(4)
+		# self.setFormat(fmt)
 		
 		# ugly trick to receive interaction events in a different function than QOpenGLWidget.event (that one is locking the GIL during the whole rendering, killing any possibility of having a computing thread aside)
 		# that event reception should be in the current widget ...


### PR DESCRIPTION
This resolves [Discussion#81](https://github.com/jimy-byerley/pymadcad/discussions/81) by giving a per-mesh access to the options, such as `display_faces`.

Sorry that it also contains the MacOS fix, please tell me if I should revert that one, but I could not test my changes without it.