### PR TITLE
Minor bug fix to pass opts to stl writer

### DIFF
--- a/madcad/io.py
+++ b/madcad/io.py
@@ -183,7 +183,7 @@ else:
 	def stl_write(mesh, file, **opts):
 		stlmesh = stl.mesh.Mesh(np.zeros(len(mesh.faces), dtype=stl.mesh.Mesh.dtype), name=mesh.options.get('name'))
 		stlmesh.vectors[:] = typedlist_to_numpy(mesh.points, 'f4')[typedlist_to_numpy(mesh.faces, 'i4')]
-		stlmesh.save(file)
+		stlmesh.save(file, **opts)
 
 '''
 	OBJ is loaded using the pywavefront module	https://github.com/pywavefront/PyWavefront


### PR DESCRIPTION
Can't believe I PR'd this but here we go. I originally mutated the pip-package files which made sharing my scripts a pain.
I'm doing this for the sole purpose of being able to:
```python
write(mesh=msh, name='msh.stl', type="stl", mode=Mode.ASCII)
```
As right now, the mode argument wouldn't be passed to the actual STL writer.