### PR TITLE
improved some conventions of `madcad.gear`

### DIFF
--- a/madcad/gear.py
+++ b/madcad/gear.py
@@ -21,7 +21,7 @@
 		>>> ext_radius = (3 * 12) / (2 * pi) - 3
 		>>> int_radius = 4
 		>>> geargather(
-		...	 gearexterior(repeat_circular(gearprofile(3, 30), 30), depth=4),
+		...	 gearexterior(repeataround(gearprofile(3, 30), 30), depth=4),
 		...	 gearstructure("rounded", ext_radius, int_radius, 2, patterns=6),
 		...	 my_hub_mesh,
 		... )
@@ -250,15 +250,6 @@ def involuteof(c, t0, d, t):
 def angle(p):
 	return atan2(p[1], p[0])
 
-
-def repeat_circular(profile, n: int) -> Wire:
-	''' Repeat n times the given Wire by rotation around (O,Z) '''
-	result = repeat(profile, n, rotatearound(
-		anglebt(noproject(profile[0],Z), noproject(profile[-1],Z)),
-		(O,Z),
-		))
-	result.mergeclose()
-	return result
 
 
 def pattern_full(ext_radius, int_radius, depth, int_height=0, **kwargs) -> Mesh:
@@ -643,7 +634,7 @@ def gearstructure(
 
 		ext_radius (float):
 
-				given by the attribut `_radius` of the result of `repeat_circular` -
+				given by the attribut `_radius` of the result of `repeataround` -
 				to avoid interference, it must be smaller than `_radius` (for instance 0.95 * `_radius`))
 
 		int_radius (float):	it is the same radius of the largest radius of the hub part
@@ -849,7 +840,7 @@ def gear(
 		- `int_height` impacts the height of the hub unless specified.
 		- if `hub_height` is null, there will be no hub.
 	"""
-	# profile = repeat_circular(gearprofile(step, teeth, **kwargs), teeth)
+	# profile = repeataround(gearprofile(step, teeth, **kwargs), teeth)
 	profile = gearprofile(step, teeth, **kwargs)
 
 	# Parts

--- a/tests/test_gear.py
+++ b/tests/test_gear.py
@@ -32,7 +32,7 @@ def test_gear(name, *args, **kwargs):
 		raise
 	else:
 		results.append(mesh)
-	#show([mesh])
+	show([mesh])
 
 def testing(function):
 	def wrapper(name, *args, **kwargs):

--- a/tests/test_gearprofile.py
+++ b/tests/test_gearprofile.py
@@ -5,23 +5,23 @@ settings.resolution = ('rad', 0.05)
 
 axis = (vec3(0),vec3(0,0,1))
 
-z = 8
+teeth = 8
 step = 1
-alpha = radians(20)
-h = 0.5 * 2.25 * step/pi * cos(alpha)/cos(radians(20))
-e = 0.5*h
-p = step*z / (2*pi)
-prof = gear.gearprofile(step, z, h, e, alpha)
+pressure_angle = radians(20)
+height = 0.5 * 2.25 * step/pi * cos(pressure_angle)/cos(radians(20))
+offset = 0.5*height
+primitive = step*teeth / (2*pi)
+prof = gear.gearprofile(step, teeth, height, offset, pressure_angle=pressure_angle)
 
 show([
 	vec3(0),
 	vec3(1,0,0),
-	(vec3(p,0,0), vec3(1,0,0)),
+	(vec3(primitive,0,0), vec3(1,0,0)),
 	
-	web(prof) + web(prof).transform(angleAxis(2*pi/z, vec3(0,0,1))),
+	web(prof) + web(prof).transform(angleAxis(2*pi/teeth, vec3(0,0,1))),
 	
-	Circle(axis, p),
-	Circle(axis, p * cos(alpha)),
-	Circle(axis, p +h +e),
-	Circle(axis, p -h +e),
-	], {'display_points':True})
+	Circle(axis, primitive),
+	Circle(axis, primitive * cos(pressure_angle)),
+	Circle(axis, primitive +height +offset),
+	Circle(axis, primitive -height +offset),
+	], display_points=True)


### PR DESCRIPTION
- renamed few arguments to more meaningful names (`z` becomes `teeth` for the teeth number, `alpha` becomes `pressure_angle` ...)
- `gearprofile` now has the same phase start than `spherical_gearprofile`
- fixed numeric issues sometimes occuring in the boolean operations generating teeth in `gearexterior`